### PR TITLE
Fix ansible name conflict w/group and host

### DIFF
--- a/cluster.yml
+++ b/cluster.yml
@@ -74,7 +74,7 @@
     - role: dashd-generate-miner
       when: dash_network != "mainnet"
 
-- hosts: web
+- hosts: faucet-web
   become: true
   roles:
     - multifaucet

--- a/terraform/aws/inventory/ansible_inventory.tpl
+++ b/terraform/aws/inventory/ansible_inventory.tpl
@@ -1,6 +1,6 @@
 ${all_hosts}
 
-[web]
+[faucet-web]
 ${web_hosts}
 
 [wallet-nodes]


### PR DESCRIPTION
Current ansible warning due to same group and host name:

```
[WARNING]: Found both group and host with same name: web
```